### PR TITLE
Add NIX_PATH action input

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,7 @@ name: "install-nix-action test"
 on:
   pull_request:
   push:
+
 jobs:
   simple-build:
     strategy:
@@ -19,6 +20,7 @@ jobs:
     # cachix should be available and be able to configure a cache
     - run: cachix use cachix
     - run: nix-build test.nix
+
   no-channel:
     strategy:
       matrix:
@@ -34,3 +36,19 @@ jobs:
         skip_adding_nixpkgs_channel: true
     - run: nix-build test.nix && exit 1 || echo "OK"
     - run: NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs/tarball/ab5863afada3c1b50fc43bf774b75ea71b287cde nix-build test.nix
+
+  custom-nix-path:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v2
+    - run: yarn install --frozen-lockfile
+    - run: yarn build
+    - name: Install Nix
+      uses: ./
+      with:
+        nix_path: nixpkgs=channel:nixos-20.03
+    - run: test $NIX_PATH == "nixpkgs=channel:nixos-20.03"
+    - run: nix-build test.nix

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: cachix/install-nix-action@v9
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
     - run: nix-build
 ```
 
@@ -28,7 +30,9 @@ with developers.
 
 ## Options `with: ...`
 
-- `install_url`: specify URL to install Nix from (mostly useful for testing non-stable releases
+- `install_url`: specify URL to install Nix from (mostly useful for testing non-stable releases)
+
+- `nix_path`: set `NIX_PATH` environment variable (if set `skip_adding_nixpkgs_channel` will be implicitly enabled)
 
 - `skip_adding_nixpkgs_channel`: set to `true` to skip adding nixpkgs-unstable channel (and save ~5s for each job build)
 

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,8 @@ author: 'Domen Kožar'
 inputs:
   install_url:
     description: 'Installation URL that will contain a script to install Nix'
+  nix_path:
+    description: 'Set NIX_PATH environment variable. If set "skip_adding_nixpkgs_channel" will be implicitly enabled'
   skip_adding_nixpkgs_channel:
     description: 'Skip adding nixpkgs-unstable channel'
 branding:

--- a/lib/install-nix.sh
+++ b/lib/install-nix.sh
@@ -6,10 +6,11 @@ sudo sh -c 'echo max-jobs = auto >> /tmp/nix.conf'
 # Allow binary caches for runner user
 sudo sh -c 'echo trusted-users = root runner >> /tmp/nix.conf'
 
-if [[ $INPUT_SKIP_ADDING_NIXPKGS_CHANNEL = "true" ]]; then
+if [[ $INPUT_SKIP_ADDING_NIXPKGS_CHANNEL = "true" || $INPUT_NIX_PATH != "" ]]; then
   extra_cmd=--no-channel-add
 else
   extra_cmd=
+  INPUT_NIX_PATH="/nix/var/nix/profiles/per-user/root/channels"
 fi
 
 sh <(curl -L ${INPUT_INSTALL_URL:-https://nixos.org/nix/install}) \
@@ -29,6 +30,7 @@ fi
 # Set paths
 echo "::add-path::/nix/var/nix/profiles/per-user/runner/profile/bin"
 echo "::add-path::/nix/var/nix/profiles/default/bin"
-if [[ $INPUT_SKIP_ADDING_NIXPKGS_CHANNEL != "true" ]]; then
-echo "::set-env name=NIX_PATH::/nix/var/nix/profiles/per-user/root/channels"
+
+if [[ $INPUT_NIX_PATH != "" ]]; then
+  echo "::set-env name=NIX_PATH::${INPUT_NIX_PATH}"
 fi


### PR DESCRIPTION
Hey, this adds a new input named `nixpkgs` as default nixpkgs channel.

Resolves https://github.com/cachix/install-nix-action/issues/17.
Resolves https://github.com/cachix/install-nix-action/issues/6.