### PR TITLE
Revert "Enable sandbox on darwin"

### DIFF
--- a/lib/install-nix.sh
+++ b/lib/install-nix.sh
@@ -31,9 +31,6 @@ sh <(curl https://nixos.org/nix/install) --daemon
 # write nix.conf again as installation overwrites it
 nixConf
 
-# Enable sandbox on Darwin/Linux
-sudo sh -c 'echo sandbox = true >> /etc/nix/nix.conf'
-
 # macOS needs certificates hints
 if [[ $OSTYPE =~ darwin ]]; then
   cert_file=/nix/var/nix/profiles/default/etc/ssl/certs/ca-bundle.crt


### PR DESCRIPTION
Reverts cachix/install-nix-action#26

```
cabal-fmt................................................................An unexpected error has occurred: PermissionError: [Errno 1] Operation not permitted
  Check the log at /private/tmp/nix-build-pre-commit-run.drv-0/.cache/pre-commit/pre-commit.log
  builder for '/nix/store/8xa7mbxhxnaviv3d8k49r5lq4b0pcdxa-pre-commit-run.drv' failed with exit code 1
```