### PR TITLE
idempotent installation

### DIFF
--- a/lib/install-nix.sh
+++ b/lib/install-nix.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+if type -p nix &>/dev/null ; then
+  echo "Aborting: Nix is already installed at $(type -p nix)"
+  exit
+fi
+
 # Configure Nix
 add_config() {
   echo "$1" | sudo tee -a /tmp/nix.conf >/dev/null


### PR DESCRIPTION
Don't run the installer if Nix has already been installed on the host.
We assume that the installed Nix is already in the desired state.

This allows to share a given pipeline between hosted and self-hosted
runners. Usually the self-hosted runners are long-lived and already have
Nix installed.