### PR TITLE
Drop unnecessary use of sudo when tee'ing nix.conf

### DIFF
--- a/lib/install-nix.sh
+++ b/lib/install-nix.sh
@@ -8,7 +8,7 @@ fi
 
 # Configure Nix
 add_config() {
-  echo "$1" | sudo tee -a /tmp/nix.conf >/dev/null
+  echo "$1" | tee -a /tmp/nix.conf >/dev/null
 }
 # Set jobs to number of cores
 add_config "max-jobs = auto"


### PR DESCRIPTION
sudo is not needed when tee'ing into /tmp/nix.conf (proof: `Install nix` on https://github.com/tinkerbell/boots/runs/2901158055?check_suite_focus=true). Without this patch, I am unable to run the `install-nix-action` successfully as I don't have sudo access on the self-hosted runner I'm trying this on, but do have `nix` installed.