### PR TITLE
Only use nix-daemon when systemd is supported

### DIFF
--- a/lib/install-nix.sh
+++ b/lib/install-nix.sh
@@ -26,8 +26,8 @@ installer_options=(
   --nix-extra-conf-file /tmp/nix.conf
 )
 
-# only use the nix-daemon if systemd is supported
-if [[ -e /run/systemd/system ]]; then
+# only use the nix-daemon settings if on darwin (which get ignored) or systemd is supported
+if [[ $OSTYPE =~ darwin || -e /run/systemd/system ]]; then
   installer_options+=(
     --daemon
     --daemon-user-count 4

--- a/lib/install-nix.sh
+++ b/lib/install-nix.sh
@@ -21,12 +21,24 @@ fi
 
 # Nix installer flags
 installer_options=(
-  --daemon
-  --daemon-user-count 4
   --no-channel-add
   --darwin-use-unencrypted-nix-store-volume
   --nix-extra-conf-file /tmp/nix.conf
 )
+
+# only use the nix-daemon if systemd is supported
+if [[ -e /run/systemd/system ]]; then
+  installer_options+=(
+    --daemon
+    --daemon-user-count 4
+  )
+else
+  # "fix" the following error when running nix*
+  # error: the group 'nixbld' specified in 'build-users-group' does not exist
+  mkdir -m 0755 /etc/nix
+  echo "build-users-group =" > /etc/nix/nix.conf
+fi
+
 if [[ $INPUT_INSTALL_OPTIONS != "" ]]; then
   IFS=' ' read -r -a extra_installer_options <<< $INPUT_INSTALL_OPTIONS
   installer_options=("${extra_installer_options[@]}" "${installer_options[@]}")


### PR DESCRIPTION
Tested like with nix-update by applying the following patch

```diff
diff --git a/.github/workflows/test.yml b/.github/workflows/test.yml
index 852dc7b..9d9dc13 100644
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: cachix/install-nix-action@v13
+    - uses: supersandro2000/install-nix-action@patch-1
       with:
         install_url: https://github.com/numtide/nix-flakes-installer/releases/download/nix-2.4pre20210604_8e6ee1b/install
     - name: build
```

and running

```ShellSession
sudo rm ~/.cache/act/ -rf && nix-shell -p act --command "sudo -E \$(which act)"
```