### PR TITLE
"daemon-user-count 4" isn't enough on big boxes

### DIFF
--- a/lib/install-nix.sh
+++ b/lib/install-nix.sh
@@ -22,7 +22,7 @@ fi
 # Nix installer flags
 installer_options=(
   --daemon
-  --daemon-user-count 4
+  --daemon-user-count `nproc`
   --no-channel-add
   --darwin-use-unencrypted-nix-store-volume
   --nix-extra-conf-file /tmp/nix.conf


### PR DESCRIPTION
Install enough nixbld daemon users so that max-jobs = auto isn't a problem on a 16+ core box

fixes #79