### PR TITLE
enable flakes & nix-command features by default

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,7 +74,6 @@ jobs:
         install_url: https://nixos-nix-install-tests.cachix.org/serve/i6laym9jw3wg9mw6ncyrk6gjx4l34vvx/install
         install_options: '--tarball-url-prefix https://nixos-nix-install-tests.cachix.org/serve'
         extra_nix_config: |
-          experimental-features = nix-command flakes
           access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
     - run: nix flake show github:NixOS/nixpkgs
 
@@ -93,4 +92,20 @@ jobs:
         nix_path: nixpkgs=channel:nixos-21.05
         install_url: https://nixos-nix-install-tests.cachix.org/serve/i6laym9jw3wg9mw6ncyrk6gjx4l34vvx/install
         install_options: '--tarball-url-prefix https://nixos-nix-install-tests.cachix.org/serve'
+    - run: nix-build test.nix
+
+  oldest-supported-installer:
+    strategy:
+        matrix:
+          os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v2.3.5
+    - run: yarn install --frozen-lockfile
+    - run: yarn build
+    - name: Install Nix
+      uses: ./
+      with:
+        nix_path: nixpkgs=channel:nixos-21.05
+        install_url: https://releases.nixos.org/nix/nix-2.3.5/install
     - run: nix-build test.nix

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ or [pin nixpkgs yourself](https://nix.dev/reference/pinning-nixpkgs.html)
 - Allows specifying extra Nix configration options via `extra_nix_config`
 - Allows specifying `$NIX_PATH` and channels via `nix_path`
 - Share `/nix/store` between builds using [cachix-action](https://github.com/cachix/cachix-action) for simple binary cache setup to speed up your builds and share binaries with your team
+- Enables `flakes` and `nix-command` experimental features by default (to disable, set ``experimental-features` via `extra_nix_config`) 
 
 ## Usage
 
@@ -57,7 +58,6 @@ jobs:
         install_url: https://nixos-nix-install-tests.cachix.org/serve/vij683ly7sl95nnhb67bdjjfabclr85m/install
         install_options: '--tarball-url-prefix https://nixos-nix-install-tests.cachix.org/serve'
         extra_nix_config: |
-          experimental-features = nix-command flakes
           access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
     - run: nix build
     - run: nix flake check

--- a/lib/install-nix.sh
+++ b/lib/install-nix.sh
@@ -18,6 +18,9 @@ add_config "trusted-users = root $USER"
 if [[ $INPUT_EXTRA_NIX_CONFIG != "" ]]; then
   add_config "$INPUT_EXTRA_NIX_CONFIG"
 fi
+if [[ ! $INPUT_EXTRA_NIX_CONFIG =~ "experimental-features" ]]; then  
+  add_config "experimental-features = nix-command flakes"
+fi
 
 # Nix installer flags
 installer_options=(


### PR DESCRIPTION
There's not much harm enabling those by default for the CI.

Fix #103 