### PR TITLE
ci: switch act to use latest instead of master

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,6 +120,6 @@ jobs:
     - uses: actions/setup-go@v2.1.4
       with:
         go-version: '^1.16'
-    - run: go install github.com/nektos/act@master
+    - run: go install github.com/nektos/act@latest
     - run: docker pull ghcr.io/catthehacker/ubuntu:js-20.04
     - run: ~/go/bin/act -P ubuntu-latest=ghcr.io/catthehacker/ubuntu:js-20.04 push -j simple-build 


### PR DESCRIPTION
v0.2.25 was released that includes required fix
https://github.com/nektos/act/releases/tag/v0.2.25

If you would like to drop `setup-go` from the workflow, `act` can be installed via `brew` (it's included on github runners)
but it would depend on https://github.com/Homebrew/homebrew-core/pull/89923 first