### PR TITLE
install-nix.sh: ensure user profile comes before default profile in PATH

### DIFF
--- a/lib/install-nix.sh
+++ b/lib/install-nix.sh
@@ -78,8 +78,8 @@ if [[ $OSTYPE =~ darwin ]]; then
 fi
 
 # Set paths
-echo "/nix/var/nix/profiles/per-user/$USER/profile/bin" >> "$GITHUB_PATH"
 echo "/nix/var/nix/profiles/default/bin" >> "$GITHUB_PATH"
+echo "/nix/var/nix/profiles/per-user/$USER/profile/bin" >> "$GITHUB_PATH"
 
 if [[ $INPUT_NIX_PATH != "" ]]; then
   echo "NIX_PATH=${INPUT_NIX_PATH}" >> "$GITHUB_ENV"


### PR DESCRIPTION
Appending to `$GITHUB_PATH` *prepends* the path to `PATH`, so we need to reverse the order to make sure the user-installed nix comes before the action-installed nix.

(I am aware of the `install_url` trick, but sometimes using `nix-env` is preferable.)