### PR TITLE
option to install in single user mode

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,8 @@ inputs:
     description: 'Installation URL that will contain a script to install Nix.'
   install_options:
     description: 'Additional installer flags passed to the installer script.'
+  single_user:
+    description: 'Install Nix in single-user mode'
   nix_path:
     description: 'Set NIX_PATH environment variable.'
   extra_nix_config:
@@ -23,3 +25,4 @@ runs:
         INPUT_INSTALL_OPTIONS: ${{ inputs.install_options }}
         INPUT_NIX_PATH: ${{ inputs.nix_path }}
         INPUT_EXTRA_NIX_CONFIG: ${{ inputs.extra_nix_config }}
+        INPUT_SINGLE_USER: $${{ inputs.extra_nix_config }}

--- a/install-nix.sh
+++ b/install-nix.sh
@@ -37,7 +37,7 @@ installer_options=(
 )
 
 # only use the nix-daemon settings if on darwin (which get ignored) or systemd is supported
-if [[ $OSTYPE =~ darwin || -e /run/systemd/system ]]; then
+if [[ $OSTYPE =~ darwin || -e /run/systemd/system && $INPUT_SINGLE_USER == "true" ]]; then
   installer_options+=(
     --daemon
     --daemon-user-count "$(python3 -c 'import multiprocessing as mp; print(mp.cpu_count() * 2)')"


### PR DESCRIPTION
Installing in single user mode is useful for a few different reasons:

* [caching](https://github.com/actions/cache) is simpler. I ran into issues trying to pull the eval cache from `/root` which is why I did this in the first place
* AWS credentials are more straight forward for s3 caches. One does not have to copy credentials to `/root` in single user mode

# Potential issues/improvement

I have a Nix secret key for signing in my `extra_nix_config` and as is, this change initially broke it, since it expected the key at installation time.
I worked around it by simply placing the key before the install action, but I'd like to at least figure out why this didn't happen in daemon mode.