### PR TITLE
install-nix.sh: Collapse log messages

### DIFF
--- a/install-nix.sh
+++ b/install-nix.sh
@@ -6,6 +6,9 @@ if type -p nix &>/dev/null ; then
   exit
 fi
 
+# GitHub command to put the following log messages into a group which is collapsed by default
+echo "::group::Installing Nix"
+
 # Create a temporary workdir
 workdir=$(mktemp -d)
 trap 'rm -rf "$workdir"' EXIT
@@ -84,3 +87,6 @@ echo "/nix/var/nix/profiles/per-user/$USER/profile/bin" >> "$GITHUB_PATH"
 if [[ $INPUT_NIX_PATH != "" ]]; then
   echo "NIX_PATH=${INPUT_NIX_PATH}" >> "$GITHUB_ENV"
 fi
+
+# Close the log message group which was opened above
+echo "::endgroup::"


### PR DESCRIPTION
The Nix installer produces a significant number of log messages, but usually those messages are not really interesting.  Group those messages under a header, so that GitHub will keep them collapsed by default.

Usually log messages are collapsed under the step title anyway, but if this action is uses inside another composite action, there is no separate step title, therefore the whole Nix installer output is immediately visible when the log section for the outer composite action is expanded.  Adding the group header fixes this problem.

This should also help with complaints like #126.

-----

An example of how the log output looks when `cachix/install-nix-action` is used inside a composite action (expand the “Build” step):

- Before: https://github.com/sigprof/test-workflows/runs/7063391804?check_suite_focus=true (no way to collapse the Nix installer output if you need to look at the messages from subsequent steps of the composite action)
- After: https://github.com/sigprof/test-workflows/runs/7063571073?check_suite_focus=true (all Nix installer messages are collapsed under the “Installing Nix” header, but are still available after just one click)

(sorry, that's a very dirty testing repo).