### PR TITLE
Always set NIX_SSL_CERT_FILE

### DIFF
--- a/install-nix.sh
+++ b/install-nix.sh
@@ -72,11 +72,10 @@ done
 
 sh "$workdir/install" "${installer_options[@]}"
 
+cert_file=/nix/var/nix/profiles/default/etc/ssl/certs/ca-bundle.crt
+echo "NIX_SSL_CERT_FILE=$cert_file" >> "$GITHUB_ENV"
+export NIX_SSL_CERT_FILE=$cert_file
 if [[ $OSTYPE =~ darwin ]]; then
-  # macOS needs certificates hints
-  cert_file=/nix/var/nix/profiles/default/etc/ssl/certs/ca-bundle.crt
-  echo "NIX_SSL_CERT_FILE=$cert_file" >> "$GITHUB_ENV"
-  export NIX_SSL_CERT_FILE=$cert_file
   sudo launchctl setenv NIX_SSL_CERT_FILE "$cert_file"
 fi
 


### PR DESCRIPTION
Some things in nixpkgs expect this to be set. E.g.

    NIX_SSL_CERT_FILE= ruby -r net/http -e 'Net::HTTP.get(URI("https://example.com"))'

With `ruby` from Nixpkgs will always fail with e.g.

> SSL_connect returned=1 errno=0 state=error: certificate verify failed
> (unable to get local issuer certificate) (OpenSSL::SSL::SSLError)

However, with NIX_SSL_CERT_FILE set correctly, will succeed.