### PR TITLE
Don't add daemon option if no-daemon is supplied

### DIFF
--- a/install-nix.sh
+++ b/install-nix.sh
@@ -37,7 +37,7 @@ installer_options=(
 )
 
 # only use the nix-daemon settings if on darwin (which get ignored) or systemd is supported
-if [[ $OSTYPE =~ darwin || -e /run/systemd/system ]]; then
+if [[ (! $INPUT_INSTALL_OPTIONS =~ "--no-daemon") && ($OSTYPE =~ darwin || -e /run/systemd/system) ]]; then
   installer_options+=(
     --daemon
     --daemon-user-count "$(python3 -c 'import multiprocessing as mp; print(mp.cpu_count() * 2)')"


### PR DESCRIPTION
Hey @domenkozar 👋🏼 

I am using Fedora builders which don't like the daemon option (because of selinux).

I supplied `--no-daemon` to the installer options but saw that the installer still adds those.

This should make it so that we can do single-user installs.

Thanks! 