### PR TITLE
fix typo in github_access_token option

### DIFF
--- a/install-nix.sh
+++ b/install-nix.sh
@@ -23,7 +23,7 @@ add_config "max-jobs = auto"
 add_config "trusted-users = root $USER"
 # Add github access token
 if [[ $INPUT_GITHUB_ACCESS_TOKEN != "" ]]; then
-  add_config "access-tokens" "github.com=$INPUT_GITHUB_ACCESS_TOKEN"
+  add_config "access-tokens = github.com=$INPUT_GITHUB_ACCESS_TOKEN"
 fi
 # Append extra nix configuration if provided
 if [[ $INPUT_EXTRA_NIX_CONFIG != "" ]]; then


### PR DESCRIPTION
`add_config` only takes one argument, not two. This will cause an error when using `github_access_token`:
```
error: illegal configuration line 'access-tokens' in '/etc/nix/nix.conf'
Try 'nix-env --help' for more information.
```
This should (hopefully) fix that. On a sort of related note, the token passed to `github_access_token` will be overwritten if the user also includes `access-tokens = ...` in `extra_nix_config` (instead of merging the two); would it be worth making a PR to document this behavior in the README?