### PR TITLE
Fix rate-limits by using github.token by default

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,3 +26,4 @@ runs:
         INPUT_INSTALL_OPTIONS: ${{ inputs.install_options }}
         INPUT_INSTALL_URL: ${{ inputs.install_url }}
         INPUT_NIX_PATH: ${{ inputs.nix_path }}
+        GITHUB_TOKEN: ${{ github.token }}

--- a/install-nix.sh
+++ b/install-nix.sh
@@ -22,8 +22,10 @@ add_config "max-jobs = auto"
 # Allow binary caches for user
 add_config "trusted-users = root $USER"
 # Add github access token
-if [[ $INPUT_GITHUB_ACCESS_TOKEN != "" ]]; then
+if [[ -n "${INPUT_GITHUB_ACCESS_TOKEN:-}" ]]; then
   add_config "access-tokens = github.com=$INPUT_GITHUB_ACCESS_TOKEN"
+elif [[ -n "${GITHUB_TOKEN:-}" ]]; then
+  add_config "access-tokens = github.com=$GITHUB_TOKEN"
 fi
 # Append extra nix configuration if provided
 if [[ $INPUT_EXTRA_NIX_CONFIG != "" ]]; then


### PR DESCRIPTION
Turns out there is a default github token we can use to talk to github
and avoid the rate limit issues.
