### PR TITLE
Fix GITHUB_PATH when using nix 2.14

### DIFF
--- a/install-nix.sh
+++ b/install-nix.sh
@@ -90,6 +90,10 @@ fi
 echo "/nix/var/nix/profiles/default/bin" >> "$GITHUB_PATH"
 echo "/nix/var/nix/profiles/per-user/$USER/profile/bin" >> "$GITHUB_PATH"
 
+# new path for nix 2.14
+echo "$HOME/.local/state/nix/profile/bin" >> "$GITHUB_PATH"
+
+
 if [[ $INPUT_NIX_PATH != "" ]]; then
   echo "NIX_PATH=${INPUT_NIX_PATH}" >> "$GITHUB_ENV"
 fi


### PR DESCRIPTION
hopefully fixes the issues from https://github.com/cachix/install-nix-action/issues/161

The default profiles moved in nix 2.14 (see [here](https://github.com/NixOS/nix/pull/5226)) so this will source from the old and new locations 
