### PR TITLE
fix: Set TMPDIR to avoid disk space issues

### DIFF
--- a/install-nix.sh
+++ b/install-nix.sh
@@ -91,7 +91,7 @@ if [[ -n "${INPUT_NIX_PATH:-}" ]]; then
   echo "NIX_PATH=${INPUT_NIX_PATH}" >> "$GITHUB_ENV"
 fi
 
-# Set temporary directory (if not already set)
+# Set temporary directory (if not already set) to fix https://github.com/cachix/install-nix-action/issues/197
 if [[ -z "${TMPDIR:-}" ]]; then
   echo "TMPDIR=${RUNNER_TEMP}" >> "$GITHUB_ENV"
 fi

--- a/install-nix.sh
+++ b/install-nix.sh
@@ -91,5 +91,10 @@ if [[ -n "${INPUT_NIX_PATH:-}" ]]; then
   echo "NIX_PATH=${INPUT_NIX_PATH}" >> "$GITHUB_ENV"
 fi
 
+# Set temporary directory (if not already set)
+if [[ -z "${TMPDIR:-}" ]]; then
+  echo "TMPDIR=${RUNNER_TEMP}" >> "$GITHUB_ENV"
+fi
+
 # Close the log message group which was opened above
 echo "::endgroup::"


### PR DESCRIPTION
Set `TMPDIR` if not already set to workaround potential disk space issues while running builds in a nix shell. See NixOS/nix#395 for more info.

fixes #197