### PR TITLE
nix: 2.20.5 -> 2.21.2

### DIFF
--- a/install-nix.sh
+++ b/install-nix.sh
@@ -88,7 +88,7 @@ echo "installer options: ${installer_options[*]}"
 
 # There is --retry-on-errors, but only newer curl versions support that
 curl_retries=5
-while ! curl -sS -o "$workdir/install" -v --fail -L "${INPUT_INSTALL_URL:-https://releases.nixos.org/nix/nix-2.20.5/install}"
+while ! curl -sS -o "$workdir/install" -v --fail -L "${INPUT_INSTALL_URL:-https://releases.nixos.org/nix/nix-2.21.2/install}"
 do
   sleep 1
   ((curl_retries--))

--- a/install-nix.sh
+++ b/install-nix.sh
@@ -88,7 +88,7 @@ echo "installer options: ${installer_options[*]}"
 
 # There is --retry-on-errors, but only newer curl versions support that
 curl_retries=5
-while ! curl -sS -o "$workdir/install" -v --fail -L "${INPUT_INSTALL_URL:-https://releases.nixos.org/nix/nix-2.21.2/install}"
+while ! curl -sS -o "$workdir/install" -v --fail -L "${INPUT_INSTALL_URL:-https://releases.nixos.org/nix/nix-2.22.1/install}"
 do
   sleep 1
   ((curl_retries--))


### PR DESCRIPTION
updated version of nix used by the `install.sh` script

tested this in another project of mine by specifying `install_url` and checking for successful installation using act