### PR TITLE
Enable `always-allow-substitutes` by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ or [pin nixpkgs yourself](https://nix.dev/reference/pinning-nixpkgs)
 - Allows specifying extra Nix configuration options via `extra_nix_config`
 - Allows specifying `$NIX_PATH` and channels via `nix_path`
 - Share `/nix/store` between builds using [cachix-action](https://github.com/cachix/cachix-action) for simple binary cache setup to speed up your builds and share binaries with your team
-- Enables `flakes` and `nix-command` experimental features by default (to disable, set `experimental-features` via `extra_nix_config`)
+- Enables KVM on supported machines: run VMs and NixOS tests with full hardware-acceleration
 
 ## Usage
 
@@ -74,6 +74,19 @@ To install Nix from any commit, go to [the corresponding installer_test action](
 - `nix_path`: set `NIX_PATH` environment variable, for example `nixpkgs=channel:nixos-unstable`
 
 - `enable_kvm`: whether to enable KVM for hardware-accelerated virtualization on Linux. Enabled by default if available.
+
+
+## Differences from the default Nix installer
+
+Some settings have been optimised for use in CI environments:
+
+- `nix.conf` settings:
+
+  - The experimental `flakes` and `nix-command` features are enabled. Disable by overriding `experimental-features` in `extra_nix_config`.
+
+  - `always-allow-substitutes` is set to `true`. Disable by overriding `always-allow-substitutes` in `extra_nix_config`.
+
+- KVM is enabled if available. Disable by setting `enable_kvm: false`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -80,13 +80,25 @@ To install Nix from any commit, go to [the corresponding installer_test action](
 
 Some settings have been optimised for use in CI environments:
 
-- `nix.conf` settings:
+- `nix.conf` settings. Override these defaults with `extra_nix_config`:
 
   - The experimental `flakes` and `nix-command` features are enabled. Disable by overriding `experimental-features` in `extra_nix_config`.
 
-  - `always-allow-substitutes` is set to `true`. Disable by overriding `always-allow-substitutes` in `extra_nix_config`.
+  - `max-jobs` is set to `auto`.
 
-- KVM is enabled if available. Disable by setting `enable_kvm: false`.
+  - `show-trace` is set to `true`.
+
+  - `$USER` is added to `trusted-users`.
+
+  - `$GITHUB_TOKEN` is added to `access_tokens` if no other `github_access_token` is provided.
+
+  - `always-allow-substitutes` is set to `true`.
+
+  - `ssl-cert-file` is set to `/etc/ssl/cert.pem` on macOS.
+
+- KVM is enabled on Linux if available. Disable by setting `enable_kvm: false`.
+
+- `$TMPDIR` is set to `$RUNNER_TEMP` if empty.
 
 ---
 

--- a/install-nix.sh
+++ b/install-nix.sh
@@ -56,6 +56,11 @@ fi
 if [[ ! $INPUT_EXTRA_NIX_CONFIG =~ "experimental-features" ]]; then
   add_config "experimental-features = nix-command flakes"
 fi
+# Always allow substituting from the cache, even if the derivation has `allowSubstitutes = false`.
+# This is a CI optimisation to avoid having to download the inputs for already-cached derivations to rebuild trivial text files.
+if [[ ! $INPUT_EXTRA_NIX_CONFIG =~ "always-allow-substitutes" ]]; then
+  add_config "always-allow-substitutes = true"
+fi
 
 # Nix installer flags
 installer_options=(


### PR DESCRIPTION
A typical CI machine will have fast internet access, but may not have all the inputs already in the store to rebuild trivial derivations marked with `allowSubstitutes = false`. This leads to expensive cycles of downloads and rebuilds for derivations like the top-level NixOS system, which will be rebuilt from scratch on every CI run, despite being cached.