### PR TITLE
ci: fix tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
   simple-build:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-13]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
@@ -25,7 +25,7 @@ jobs:
   custom-nix-path:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-13]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
@@ -39,7 +39,7 @@ jobs:
   extra-nix-config:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-13]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
@@ -55,7 +55,7 @@ jobs:
   flakes:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-13]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
@@ -66,7 +66,7 @@ jobs:
   installer-options:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-13]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
@@ -81,7 +81,7 @@ jobs:
   oldest-supported-installer:
     strategy:
         matrix:
-          os: [ubuntu-latest, macos-latest]
+          os: [ubuntu-latest, macos-13]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,8 +8,12 @@ on:
 jobs:
   simple-build:
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13]
+        os:
+        - ubuntu-latest
+        - macos-latest
+        - macos-13
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
@@ -22,10 +26,15 @@ jobs:
     # cachix should be available and be able to configure a cache
     - run: cachix use cachix
     - run: nix-build test.nix
+
   custom-nix-path:
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13]
+        os:
+        - ubuntu-latest
+        - macos-latest
+        - macos-13
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
@@ -38,8 +47,12 @@ jobs:
 
   extra-nix-config:
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13]
+        os:
+        - ubuntu-latest
+        - macos-latest
+        - macos-13
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
@@ -54,8 +67,12 @@ jobs:
 
   flakes:
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13]
+        os:
+        - ubuntu-latest
+        - macos-latest
+        - macos-13
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
@@ -65,8 +82,12 @@ jobs:
 
   installer-options:
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13]
+        os:
+        - ubuntu-latest
+        # - macos-latest missing installer for aarch64-darwin
+        - macos-13
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
@@ -80,8 +101,12 @@ jobs:
 
   oldest-supported-installer:
     strategy:
-        matrix:
-          os: [ubuntu-latest, macos-13]
+      fail-fast: false
+      matrix:
+        os:
+        - ubuntu-latest
+        - macos-latest
+        - macos-13
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
@@ -94,8 +119,8 @@ jobs:
 
   act-support:
     strategy:
-        matrix:
-          os: [ubuntu-latest]
+      matrix:
+        os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - master
 
+env:
+  nixpkgs_channel: nixpkgs=channel:nixos-23.11
+
 jobs:
   simple-build:
     strategy:
@@ -20,7 +23,7 @@ jobs:
     - name: Install Nix
       uses: ./
       with:
-        nix_path: nixpkgs=channel:nixos-22.11
+        nix_path: ${{ env.nixpkgs_channel }}
     - run: nix-env -iA cachix -f https://cachix.org/api/v1/install
     - run: cat /etc/nix/nix.conf
     # cachix should be available and be able to configure a cache
@@ -41,8 +44,8 @@ jobs:
     - name: Install Nix
       uses: ./
       with:
-        nix_path: nixpkgs=channel:nixos-20.03
-    - run: test $NIX_PATH == "nixpkgs=channel:nixos-20.03"
+        nix_path: ${{ env.nixpkgs_channel }}
+    - run: test $NIX_PATH == '${{ env.nixpkgs_channel }}'
     - run: nix-build test.nix
 
   extra-nix-config:
@@ -59,7 +62,7 @@ jobs:
     - name: Install Nix
       uses: ./
       with:
-        nix_path: nixpkgs=channel:nixos-22.11
+        nix_path: ${{ env.nixpkgs_channel }}
         extra_nix_config: |
           sandbox = relaxed
     - run: cat /etc/nix/nix.conf
@@ -94,7 +97,7 @@ jobs:
     - name: Install Nix
       uses: ./
       with:
-        nix_path: nixpkgs=channel:nixos-22.11
+        nix_path: ${{ env.nixpkgs_channel }}
         install_options: --tarball-url-prefix https://nixos-nix-install-tests.cachix.org/serve
         install_url: https://nixos-nix-install-tests.cachix.org/serve/s62m7lc0q0mz2mxxm9q0kkrcg90njzhq/install
     - run: nix-build test.nix
@@ -113,7 +116,7 @@ jobs:
     - name: Install Nix
       uses: ./
       with:
-        nix_path: nixpkgs=channel:nixos-22.11
+        nix_path: ${{ env.nixpkgs_channel }}
         install_url: https://releases.nixos.org/nix/nix-2.8.0/install
     - run: nix-build test.nix
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,10 @@ on:
 
 env:
   nixpkgs_channel: nixpkgs=channel:nixos-23.11
+  oldest_supported_installer: nix-2.8.0
+  # Fetch new versions from the Nix CI run: https://github.com/NixOS/nix/blob/master/.github/workflows/ci.yml
+  # TODO: add pinning upstream or rethink this
+  pinned_installer_hash: zfzfrbb59jsqrfkldwj8drcr9nhhc49k
 
 jobs:
   simple-build:
@@ -99,7 +103,7 @@ jobs:
       with:
         nix_path: ${{ env.nixpkgs_channel }}
         install_options: --tarball-url-prefix https://nixos-nix-install-tests.cachix.org/serve
-        install_url: https://nixos-nix-install-tests.cachix.org/serve/s62m7lc0q0mz2mxxm9q0kkrcg90njzhq/install
+        install_url: https://nixos-nix-install-tests.cachix.org/serve/${{ env.pinned_installer_hash }}/install
     - run: nix-build test.nix
 
   oldest-supported-installer:
@@ -117,7 +121,7 @@ jobs:
       uses: ./
       with:
         nix_path: ${{ env.nixpkgs_channel }}
-        install_url: https://releases.nixos.org/nix/nix-2.8.0/install
+        install_url: https://releases.nixos.org/nix/${{ env.oldest_supported_installer }}/install
     - run: nix-build test.nix
 
   act-support:


### PR DESCRIPTION
- [x] Switch back to x86_64-darwin with `macos-13`
- [x] Add aarch64-darwin runs
- [x] Fix aarch64-darwin custom installer test. Missing installer hash in cached script.
- [x] Fix x86_64-darwin custom installer test. 404 fetching cached installer.