### PR TITLE
Update README: hardware accel is available now...

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,10 +118,9 @@ With the following inputs:
 ```yaml
 - uses: cachix/install-nix-action@vXX
   with:
+    enable_kvm: true
     extra_nix_config: "system-features = nixos-test benchmark big-parallel kvm"
 ```
-
-[Note that there's no hardware acceleration on GitHub Actions.](https://github.com/actions/virtual-environments/issues/183#issuecomment-610723516).
 
 ### How do I install packages via nix-env from the specified `nix_path`?
 


### PR DESCRIPTION
...at least with enable_kvm yes. Issue linked in the note was closed accordingly. So I think the old note was outdated as of https://github.com/cachix/install-nix-action/commit/fe19c91c6b0293441aca084e88a60ee59640922c