### PR TITLE
Nix: 2.24.6 -> 2.24.7

### DIFF
--- a/install-nix.sh
+++ b/install-nix.sh
@@ -93,7 +93,7 @@ echo "installer options: ${installer_options[*]}"
 
 # There is --retry-on-errors, but only newer curl versions support that
 curl_retries=5
-while ! curl -sS -o "$workdir/install" -v --fail -L "${INPUT_INSTALL_URL:-https://releases.nixos.org/nix/nix-2.24.6/install}"
+while ! curl -sS -o "$workdir/install" -v --fail -L "${INPUT_INSTALL_URL:-https://releases.nixos.org/nix/nix-2.24.7/install}"
 do
   sleep 1
   ((curl_retries--))


### PR DESCRIPTION
This version fixes GC bugs, which can be triggered under memory pressure. Since GitHub runners are at times memory constraint, it would be good to get this out.

Changelog: https://github.com/NixOS/nix/compare/2.24.6...2.24.7