### PR TITLE
Nix: 2.24.7 -> 2.24.8

### DIFF
--- a/install-nix.sh
+++ b/install-nix.sh
@@ -93,7 +93,7 @@ echo "installer options: ${installer_options[*]}"
 
 # There is --retry-on-errors, but only newer curl versions support that
 curl_retries=5
-while ! curl -sS -o "$workdir/install" -v --fail -L "${INPUT_INSTALL_URL:-https://releases.nixos.org/nix/nix-2.24.7/install}"
+while ! curl -sS -o "$workdir/install" -v --fail -L "${INPUT_INSTALL_URL:-https://releases.nixos.org/nix/nix-2.24.8/install}"
 do
   sleep 1
   ((curl_retries--))


### PR DESCRIPTION
https://github.com/NixOS/nix/security/advisories/GHSA-6fjr-mq49-mm2c

v29 actually doesn't has the fix for this. So the release notes should be updated.