### PR TITLE
Remove deprecated `--darwin-use-unencrypted-nix-store-volume` flag

### DIFF
--- a/install-nix.sh
+++ b/install-nix.sh
@@ -65,7 +65,6 @@ fi
 # Nix installer flags
 installer_options=(
   --no-channel-add
-  --darwin-use-unencrypted-nix-store-volume
   --nix-extra-conf-file "$workdir/nix.conf"
 )
 


### PR DESCRIPTION
Fixes the following warning:

```
Warning: the flag --darwin-use-unencrypted-nix-store-volume is no longer needed and will be removed in the future.
````
