### PR TITLE
nix: 2.30.0 -> 2.30.1

### DIFF
--- a/install-nix.sh
+++ b/install-nix.sh
@@ -94,7 +94,7 @@ echo "installer options: ${installer_options[*]}"
 
 # There is --retry-on-errors, but only newer curl versions support that
 curl_retries=5
-nix_version=2.30.0
+nix_version=2.30.1
 while ! curl -sS -o "$workdir/install" -v --fail -L "${INPUT_INSTALL_URL:-https://releases.nixos.org/nix/nix-${nix_version}/install}"
 do
   sleep 1


### PR DESCRIPTION
Fix for https://github.com/NixOS/nix/security/advisories/GHSA-qc7j-jgf3-qmhg.